### PR TITLE
Fixes necessary to get this compiling on a 32-bit Linux Mint 13/Ubuntu 12.04 system.

### DIFF
--- a/AES/Makefile
+++ b/AES/Makefile
@@ -39,7 +39,7 @@ EXECUTABLE	:= AES
 CUFILES		:= aesHost.cu 
 # C/C++ source files (compiled with gcc / c++)
 CCFILES		:= aescuda.cpp  aesCudaUtils.cpp
-LINKFLAGS	:= -L$(BOOST_LIB) -lboost_filesystem$(BOOST_VER)
+LINKFLAGS	:= -L$(BOOST_LIB) -lboost_filesystem$(BOOST_VER) -lboost_system$(BOOST_VER)
 
 HDRDIR  	:= 
 NEWLIBDIR  	:= 

--- a/AES/Makefile
+++ b/AES/Makefile
@@ -50,4 +50,4 @@ CUFLAGS	:= $(CFLAGS)
 ###############################################################################
 # Rules and targets
 
-include ../../common/common.mk
+include ../common/common.mk

--- a/BFS/Makefile
+++ b/BFS/Makefile
@@ -43,5 +43,5 @@ CCFILES		:=
 ################################################################################
 # Rules and targets
 
-include ../../common/common.mk
+include ../common/common.mk
 

--- a/DG/Makefile
+++ b/DG/Makefile
@@ -62,7 +62,7 @@ NEWCPP = $(OPENMPI_BINDIR)mpicxx
 ###############################################################################
 # Rules and targets
 
-include ../../common/common.mk
+include ../common/common.mk
 
 LINKLINE += $(MPILNKOPTS) -L$(PWD)/3rdParty/ParMetis-3.1/ -lparmetis -lmetis -lm 
 

--- a/DG/Makefile
+++ b/DG/Makefile
@@ -51,9 +51,9 @@ MPILNKOPTS := $(shell $(OPENMPI_BINDIR)mpicxx --showme:link) # extract the requi
 N ?= 6
 HOSTNAME=$(shell hostname | awk '/aamodt/ {print 1;} /arch/ {print 1;}')
 ifeq ($(HOSTNAME),1)
-INCLUDES = -Dp_N=$(N) -DNDG3d -DCUDA -I/opt/local/include -I/usr/include/malloc -I$(HDRDIR) -I/opt/mpich/include
+INCLUDES = -Dp_N=$(N) -DNDG3d -DCUDA -I/opt/local/include -I/usr/include/malloc -I$(HDRDIR) -I/usr/lib/openmpi/include -I/opt/mpich/include
 else
-INCLUDES = -Dp_N=$(N) -DNDG3d -DCUDA -I/opt/local/include -I/usr/include/malloc -I$(HDRDIR)  
+INCLUDES = -Dp_N=$(N) -DNDG3d -DCUDA -I/opt/local/include -I/usr/include/malloc -I$(HDRDIR) -I/usr/lib/openmpi/include
 endif
 
 NEWCC = $(OPENMPI_BINDIR)mpicc

--- a/LIB/Makefile
+++ b/LIB/Makefile
@@ -44,5 +44,5 @@ GPGPUSIM_ROOT  := ..
 
 ################################################################################
 # Rules and targets
-include ../../common/common.mk
+include ../common/common.mk
 

--- a/LPS/Makefile
+++ b/LPS/Makefile
@@ -21,5 +21,5 @@ GPGPUSIM_ROOT  := ..
 ################################################################################
 # Rules and targets
 
-include ../../common/common.mk
+include ../common/common.mk
 

--- a/MUM/Makefile
+++ b/MUM/Makefile
@@ -48,4 +48,4 @@ CCFILES		:= \
 # Rules and targets
 
 GPGPUSIM_ROOT := ..
-include ../../common/common.mk
+include ../common/common.mk

--- a/Makefile.ispass-2009
+++ b/Makefile.ispass-2009
@@ -5,10 +5,10 @@ BINSUBDIR=release
 SETENV=export BINDIR=$(BINDIR); \
 	   export ROOTDIR=$(NVIDIA_COMPUTE_SDK_LOCATION)/C/src/; \
 	   export BINSUBDIR=$(BINSUBDIR); \
-	   export BOOST_LIB=/usr/lib64; \
+	   export BOOST_LIB=/usr/lib; \
 	   export BOOST_ROOT=/usr/include; \
 	   export BOOST_VER=""; \
-	   export OPENMPI_BINDIR=/usr/lib64/mpi/gcc/openmpi/bin/; 
+	   export OPENMPI_BINDIR=""; 
 noinline?=0
 
 .PHONY: check_environment

--- a/NN/Makefile
+++ b/NN/Makefile
@@ -45,4 +45,4 @@ GPGPUSIM_ROOT   := ..
 ###############################################################################
 # Rules and targets
 
-include ../../common/common.mk
+include ../common/common.mk

--- a/NQU/Makefile
+++ b/NQU/Makefile
@@ -45,6 +45,6 @@ GPGPUSIM_ROOT  := ..
 ################################################################################
 # Rules and targets
 
-include ../../common/common.mk
+include ../common/common.mk
 
 

--- a/RAY/Makefile
+++ b/RAY/Makefile
@@ -47,4 +47,4 @@ GPGPUSIM_ROOT   := ..
 # Rules and targets
 #LIB := 
 
-include ../../common/common.mk
+include ../common/common.mk

--- a/STO/Makefile
+++ b/STO/Makefile
@@ -50,4 +50,4 @@ CCFILES		:= storeCPU.cpp md5_cpu.cpp sha1_cpu.cpp
 ################################################################################
 # Rules and targets
 
-include ../../common/common.mk
+include ../common/common.mk

--- a/WP/makefile
+++ b/WP/makefile
@@ -98,7 +98,7 @@ INTERMED_FILES := *.cpp*.i *.cpp*.ii *.cu.c *.cudafe*.* *.fatbin.c *.cubin *.has
 CUDAHOME=$(CUDA_INSTALL_PATH)
 
 NVOPENCC_VER:=$(shell $$CUDAHOME/open64/bin/nvopencc --version 2>&1 | awk '/GPGPU-Sim/ {printf("_nvopencc_CL%d", $$3);}')
-GPGPULINK = -L$(CUDAHOME)/lib64/ -lcudart -L$(NVIDIA_COMPUTE_SDK_LOCATION)/C/lib/ -lcutil_x86_64 -lm -lz -ldl -lGL -lstdc++ $(NEWLIBDIR) $(LIB) # /usr/lib64/libstdc++.so.6 
+GPGPULINK = -L$(CUDAHOME)/lib64/ -L$(CUDAHOME)/lib/ -lcudart -L$(NVIDIA_COMPUTE_SDK_LOCATION)/C/lib/ -lcutil -lm -lz -ldl -lGL -lstdc++ $(NEWLIBDIR) $(LIB) # /usr/lib64/libstdc++.so.6 
 .SUFFIXES :
 
 all : vanilla $(BINDIR)/$(BINSUBDIR)/WP compare_snaps


### PR DESCRIPTION
I do not know if all of these changes will be necessary for everyone. Also, since I can only test on my computer, I cannot guarantee that these changes won't break the build for someone else. I'm not suggesting that these changes necessarily be merged "as-is" without more extensive testing than I can do.

These changes are simply the changes I needed to make to get it compiling on my particular computer.

The CUDA SDK version 3.1 also includes a file C/common/common.mk, which I had to modify by changing line 333 from this:
    LINKLINE  = $(LINK) -o $(TARGET) $(OBJS) $(LIB)
to this:
    LINKLINE  = $(LINK) -o $(TARGET) $(OBJS) $(LIB) $(LINKFLAGS)
Otherwise it wouldn't compile.
